### PR TITLE
AutoForm: Bump ECS desired count to 3, update ALB health check path to /v2/health, and add a new DynamoDB module called 'session_store'.

### DIFF
--- a/infra/aws/alb/main.tf
+++ b/infra/aws/alb/main.tf
@@ -17,7 +17,7 @@ resource "aws_lb_target_group" "tg" {
   target_type = "ip"
   vpc_id      = var.vpc_id
   health_check {
-    path                = "/v1/models"
+  path = "/v2/health"
     healthy_threshold   = 2
     unhealthy_threshold = 3
     matcher             = "200-499"

--- a/infra/aws/dynamodb/session_store.tf
+++ b/infra/aws/dynamodb/session_store.tf
@@ -1,0 +1,9 @@
+resource "aws_dynamodb_table" "session_store" {
+  name         = "session_store"
+  billing_mode = "PAY_PER_REQUEST"
+  attribute {
+    name = "session_id"
+    type = "S"
+  }
+  ...
+}

--- a/infra/aws/ecs/main.tf
+++ b/infra/aws/ecs/main.tf
@@ -44,7 +44,7 @@ resource "aws_ecs_service" "this" {
   name            = "litellm-service"
   cluster         = aws_ecs_cluster.this.id
   task_definition = aws_ecs_task_definition.this.arn
-  desired_count   = 1
+  desired_count = 3
   launch_type     = "FARGATE"
 
   network_configuration {


### PR DESCRIPTION
This PR was **auto‑generated** by **AutoForm** for task:

> Bump ECS desired count to 3, update ALB health check path to /v2/health, and add a new DynamoDB module called 'session_store'.

Please review the Terraform changes.